### PR TITLE
(#363) Fix wrong secret names after bad copy&paste

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -118,8 +118,8 @@ pipeline {
           deleteDir()
           unstash 'compiledSource'
           dir("${BASE_DIR}") {
-            withSecretVault(secret: 'secret', user_var_name: 'ACCESS_KEY', pass_var_name: 'SECRET_ACCESS_KEY'){
-              withSecretVault(secret: 'secret', pass_var_name: 'NPM_PASSWORD'){
+            withSecretVault(secret: 'secret/code-team/ci/aws-upload-key', user_var_name: 'ACCESS_KEY', pass_var_name: 'SECRET_ACCESS_KEY'){
+              withSecretVault(secret: 'secret/code-team/ci/npm-token', pass_var_name: 'NPM_PASSWORD'){
                 script {
                   docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
                     env.HOME = "${WORKSPACE}"

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Simple Git
-[![NPM version](http://img.shields.io/npm/v/simple-git.svg)](https://www.npmjs.com/package/@elastic/simple-git) [![Build Status](https://travis-ci.org/elastic/simple-git.svg?branch=master)](https://travis-ci.org/elastic/simple-git)
+[![NPM version](http://img.shields.io/npm/v/simple-git.svg)](https://www.npmjs.com/package/@elastic/simple-git) [![Build Status](https://travis-ci.org/elastic/simple-git.svg?branch=master)](https://travis-ci.org/elastic/simple-git) [![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=code%2Fcode-simple-git%2Fmaster&build=1)](https://apm-ci.elastic.co/job/code/job/code-simple-git/job/master/1/)
 
 A light weight interface for running git commands in any [node.js](http://nodejs.org) application.
 


### PR DESCRIPTION
## What does this PR do?
It fixes the proper secret names for the deploy stage, which were wrong.

## Why is it important?
The deploy stage will be executed on each git tag, so we must ensure the secrets are in place in the  Elastic's secrets infrastructure. We must ensure that following secrets do exist with proper values:
- secret/code-team/ci/aws-upload-key -> `aws_access_key` and `aws_secret_key` used in the upload.sh script
- secret/code-team/ci/npm-token -> `auth_token` used in the upload.sh script