### PR TITLE
Add windows support at CI level

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
           }
         }
         stage('Integration Tests') {
-          agent { label 'linux && immutable' }
+          // agent { label 'linux && immutable' } Reusing top level build agent
           options { skipDefaultCheckout() }
           steps {
             deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,31 +53,31 @@ pipeline {
         }
       }
     }
-    stage('Tests') {
-      parallel {
-        stage('Unit Tests') {
-          // agent { label 'linux && immutable' } Reusing top level build agent
-          options { skipDefaultCheckout() }
-          steps {
-            deleteDir()
-            unstash 'compiledSource'
-            script {
-              withGithubNotify(context: 'Unit Test', tab: 'tests') {
-                docker.image("node:10").inside(){
-                  dir("${BASE_DIR}") {
-                    sh(label: 'Unit Tests', script: 'yarn run test:ci:unit')
-                  }
-                }
+    stage('Unit Tests') {
+      // agent { label 'linux && immutable' } Reusing top level build agent
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        unstash 'compiledSource'
+        script {
+          withGithubNotify(context: 'Unit Test', tab: 'tests') {
+            docker.image("node:10").inside(){
+              dir("${BASE_DIR}") {
+                sh(label: 'Unit Tests', script: 'yarn run test:ci:unit')
               }
             }
           }
-          post {
-            always {
-              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-unit.xml")
-            }
-          }
         }
-        stage('Integration Tests') {
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-unit.xml")
+        }
+      }
+    }
+    stage('Integration Tests') {
+      parallel {
+        stage('Linux') {
           // agent { label 'linux && immutable' } Reusing top level build agent
           options { skipDefaultCheckout() }
           steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -99,6 +99,33 @@ pipeline {
             }
           }
         }
+        stage('Windows') {
+          agent { label 'windows-2019-immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH="${PATH};C:\\Program Files\\nodejs;C:\\Program Files (x86)\\Yarn\\bin"
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir(BASE_DIR) {
+              powershell label: 'Install tools', script: ".\\.ci\\scripts\\windows\\install-node.ps1"
+              bat label: 'Yarn Install', script: 'yarn install --ignore-scripts'
+              bat label: 'Build', script: 'node scripts/build.js'
+              bat label: 'Yarn Install', script: 'yarn install --frozen-lockfile'
+              bat label: 'Tool versions', script: '''
+                npm --version
+                node --version
+              '''
+              bat label: 'Integration tests', script: 'yarn run test:ci:integration'
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-integration.xml")
+            }
+          }
+        }
       }
     }
     stage('Deploy') {

--- a/.ci/scripts/windows/install-node.ps1
+++ b/.ci/scripts/windows/install-node.ps1
@@ -1,0 +1,14 @@
+# Abort with non zero exit code on errors
+$ErrorActionPreference = "Stop"
+
+Write-Host "List environment variables..."
+Get-ChildItem Env: | Sort Name | Format-Table -Wrap -AutoSize
+
+Write-Host "Getting latest Nodejs version..."
+$Version = $(choco list nodejs --by-id-only --all) | Select-String -Pattern "nodejs $env:NODE_VERSION" | %{$_.ToString().split(" ")[1]} | sort {[version] $_} | Select-Object -Last 1
+
+Write-Host "Installing Nodejs..."
+& choco install nodejs --no-progress -y --version "$Version"
+
+Write-Host "Installing Yarn..."
+& choco install yarn --no-progress -y --version "1.19.1"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "glob": "^7.1.4",
     "mocha": "^6.2.0",
     "mocha-junit-reporter": "^1.23.1",
+    "run-script-os": "^1.0.7",
     "sinon": "^7.3.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.6.2"
@@ -44,6 +45,7 @@
   "scripts": {
     "build": "tsc -p .",
     "types": "tsc -d --emitDeclarationOnly --allowJs false --declarationDir ./dist && cp src/*.d.ts dist",
+    "types:windows": "tsc -d --emitDeclarationOnly --allowJs false --declarationDir ./dist && copy src/*.d.ts dist",
     "test": "yarn run build && yarn run test:unit && yarn run test:integration",
     "test:ci": "yarn run build && yarn run test:ci:unit && yarn run test:ci:integration",
     "test:unit": "ts-node ./node_modules/mocha/bin/mocha test/runner.ts test/unit/test*.*",
@@ -53,7 +55,8 @@
     "preversion": "yarn test",
     "postversion": "npm publish && git push && git push --tags",
     "postinstall": "node scripts/postinstall.js",
-    "prepublish": "yarn run build && yarn run types"
+    "prepublish": "yarn run build && yarn run types",
+    "prepublish:windows": "yarn run build && yarn run types:windows"
   },
   "git_natives": {
     "linux": {


### PR DESCRIPTION
## What does this PR do?
It adds windows support to the CI build, using requesting a Windows build agent to perform build tasks. To allow running custom NPM scripts in a cross-platform manner, we are adding the a dev dependency with [`run-script-os`](https://www.npmjs.com/package/run-script-os) package.

Besides that, we are reusing one Linux build agent to speed up the build

## Why is it important?
It increases build coverage across different OS platforms